### PR TITLE
feat: add CLAUDE.md and connection aliases module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md — bash_profile
+
+## What this repo is
+
+Personal shell profile (bash on Linux, zsh on macOS). It's sourced on every terminal session via `~/.bash_profile` or `~/.zshrc`. Changes here affect the user's live shell environment.
+
+## Repo structure
+
+- `src/profile.bash` — entry point, sources all modules
+- `src/terminal_shortcuts_*.bash` — alias/function modules grouped by domain
+- `src/scripts/` — helper scripts sourced or invoked by aliases
+- `install.bash` — installer that symlinks/copies into the user's rc file
+- `Brewfile` — Homebrew bundle manifest for optional CLI tools
+
+## Conventions
+
+### File naming
+- Module files: `src/terminal_shortcuts_<domain>.bash`
+- Script files: `src/scripts/<name>.bash`
+- All files use `#!/bin/bash` shebang for portability (works in both bash and zsh)
+
+### Alias naming
+- **Short lowercase**, no separators: `gs`, `gb`, `dps`, `lsa`
+- **Prefixed by domain** when grouping related commands: `gh*` for GitHub, `d*` for Docker, `g*` for git
+- Host/connection aliases use `ssh_<host>` pattern (underscores allowed for readability)
+- Modern tool aliases guard with `command -v <tool> &>/dev/null &&` so they only activate when installed
+
+### Shell compatibility
+- Must work in both bash and zsh
+- Use `[ -n "$BASH_VERSION" ]` / `[ -n "$ZSH_VERSION" ]` guards when behaviour differs
+- Use `command -v` instead of `which` for portability
+- Use `&>/dev/null` for output suppression
+
+### Adding a new module
+1. Create `src/terminal_shortcuts_<domain>.bash`
+2. Add `_bp_source "$bash_profile_wdir/terminal_shortcuts_<domain>.bash"` to `src/profile.bash`
+3. Add commands to `src/scripts/help.bash` so `bphelp` shows them
+4. Update `README.md` command table
+
+## Testing changes
+
+```bash
+source src/profile.bash   # reload in current shell
+bphelp                    # verify help output
+```
+
+## Do not
+
+- Break existing aliases — they may be in muscle memory
+- Add aliases that shadow common system commands without a guard
+- Hardcode paths — use `$bash_profile_wdir` for repo-relative paths
+- Commit machine-specific secrets (IPs in aliases are fine, passwords/keys are not)

--- a/src/profile.bash
+++ b/src/profile.bash
@@ -48,6 +48,9 @@ _bp_source "$bash_profile_wdir/terminal_shortcuts_git.bash"
 ## include modern enhancements (only activates tools that are installed)
 _bp_source "$bash_profile_wdir/terminal_shortcuts_modern.bash"
 
+## include host/connection aliases
+_bp_source "$bash_profile_wdir/terminal_shortcuts_connect.bash"
+
 ## modern unified IP tool
 source "$bash_profile_wdir/scripts/myip.bash"
 

--- a/src/terminal_shortcuts_connect.bash
+++ b/src/terminal_shortcuts_connect.bash
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+## SSH connections
+alias ssh_tower="ssh root@192.168.0.102"


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with baseline repo conventions, shell compatibility rules, and module workflow instructions
- Add `src/terminal_shortcuts_connect.bash` — new module for host/SSH connection aliases (starts with `ssh_tower`)
- Wire the new module into `src/profile.bash`

## Test plan
- [ ] `source src/profile.bash` loads without errors
- [ ] `ssh_tower` alias is available after sourcing
- [ ] Existing aliases unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)